### PR TITLE
clear diagnostic after format

### DIFF
--- a/lua/guard/format.lua
+++ b/lua/guard/format.lua
@@ -39,6 +39,8 @@ local function update_buffer(bufnr, new_lines, srow, erow)
     return
   end
 
+  vim.diagnostic.hide(nil, bufnr)
+
   -- Apply diffs in reverse order.
   for i = #diffs, 1, -1 do
     local new_start, new_count, prev_start, prev_count = unpack(diffs[i])


### PR DESCRIPTION
DISCLAIMER: It doesn't work for LSP format.  i tried to clear the diagnostics after the "format" but for some reason, guard adds the diagnostics from before the format.

Partially solves: https://github.com/nvimdev/guard.nvim/issues/22

Need to solve the LSP format too