### PR TITLE
feat: more formatters

### DIFF
--- a/lua/guard/tools/formatter.lua
+++ b/lua/guard/tools/formatter.lua
@@ -57,4 +57,45 @@ M.mixformat = {
   fname = true,
 }
 
+M.djhtml = {
+  cmd = 'djhtml',
+  args = { '-' },
+  stdin = true
+}
+
+M.cbfmt = {
+  cmd = 'cbfmt',
+  args = { '--best-effort', '--stdin-filepath' },
+  stdin = true,
+  fname = true
+}
+
+M.shfmt = {
+  cmd = 'shfmt',
+  args = { '-filename' },
+  stdin = true,
+  fname = true
+}
+
+M.isort = {
+  cmd = 'isort',
+  args = { '-', '--stdout', '--filename' },
+  stdin = true,
+  fname = true
+}
+
+M.prettierd = {
+  cmd = 'prettierd',
+  args = { '--stdin-filepath' },
+  stdin = true,
+  fname = true
+}
+
+M.sql_formatter = {
+  cmd = 'sql-formatter',
+  args = { '--fix' },
+  fname = true,
+  stdout = false
+}
+
 return M


### PR DESCRIPTION
Add some more formatters.

Did not write tests (yet?) but obviously tested the formatters themselves.

Also, sql-formatter doesn't seem to work with `stdin = true` (although it does work with null-ls as shown [here](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/formatting/sql_formatter.lua)).