### PR TITLE
Support environment variable specification

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,7 @@
+guard.nvim-features	guard.nvim.txt	/*guard.nvim-features*
+guard.nvim-guard.nvim	guard.nvim.txt	/*guard.nvim-guard.nvim*
+guard.nvim-license-mit	guard.nvim.txt	/*guard.nvim-license-mit*
+guard.nvim-table-of-contents	guard.nvim.txt	/*guard.nvim-table-of-contents*
+guard.nvim-troubleshooting	guard.nvim.txt	/*guard.nvim-troubleshooting*
+guard.nvim-usage	guard.nvim.txt	/*guard.nvim-usage*
+guard.nvim.txt	guard.nvim.txt	/*guard.nvim.txt*

--- a/lua/guard/filetype.lua
+++ b/lua/guard/filetype.lua
@@ -42,6 +42,18 @@ local function box()
     return self
   end
 
+  function tbl:env(...)
+    local tool = self[current][#self[current]]
+    if type(tool) == 'string' then
+      tool = current == 'format' and require('guard.tools.formatter')[tool]
+        or require('guard.tools.linter.' .. tool)
+    end
+    -- TODO: validate?
+    -- TODO: what is ...
+    tool.env = ...
+    return self
+  end
+
   function tbl:key_alias(key)
     local _t = {
       ['lint'] = function()

--- a/lua/guard/format.lua
+++ b/lua/guard/format.lua
@@ -121,6 +121,7 @@ local function do_fmt(buf)
       if can_run then
         if config.cmd then
           config.lines = new_lines and new_lines or prev_lines
+          config.args = config.args or {}
           config.args[#config.args + 1] = config.fname and fname or nil
           config.cwd = cwd
           reload = (not reload and config.stdout == false) and true or false

--- a/lua/guard/spawn.lua
+++ b/lua/guard/spawn.lua
@@ -33,11 +33,18 @@ local function spawn(opt)
     end)
   end
 
+  opt.env = vim.tbl_extend('force', uv.os_environ(), opt.env or {})
+  local env = {}
+  for k, v in pairs(opt.env) do
+    table.insert(env, ('%s=%s'):format(k, tostring(v)))
+  end
+  opt.env = env
+
   handle = uv.spawn(opt.cmd, {
     stdio = { stdin, stdout, stderr },
     args = opt.args,
     cwd = opt.cwd,
-    env = opt.env_flat or nil,
+    env = opt.env,
   }, function(exit_code, signal)
     if timeout then
       timeout:stop()

--- a/lua/guard/tools/formatter.lua
+++ b/lua/guard/tools/formatter.lua
@@ -91,11 +91,9 @@ M.prettierd = {
   fname = true
 }
 
-M.sql_formatter = {
+M['sql-formatter'] = {
   cmd = 'sql-formatter',
-  args = { '--fix' },
-  fname = true,
-  stdout = false
+  stdin = true
 }
 
 return M

--- a/lua/guard/tools/formatter.lua
+++ b/lua/guard/tools/formatter.lua
@@ -57,4 +57,45 @@ M.mixformat = {
   fname = true,
 }
 
+M.djhtml = {
+  cmd = 'djhtml',
+  args = { '-' },
+  stdin = true
+}
+
+M.cbfmt = {
+  cmd = 'cbfmt',
+  args = { '--best-effort', '--stdin-filepath' },
+  stdin = true,
+  fname = true
+}
+
+M.shfmt = {
+  cmd = 'shfmt',
+  args = { '-filename' },
+  stdin = true,
+  fname = true
+}
+
+M.isort = {
+  cmd = 'isort',
+  args = { '-', '--stdout', '--filename' },
+  stdin = true,
+  fname = true
+}
+
+M.prettierd = {
+  cmd = 'prettierd',
+  args = { '--stdin-filepath' },
+  stdin = true,
+  fname = true
+}
+
+M.sql_formatter = {
+  cmd = 'sql-formatter',
+  args = { '--fix' },
+  fname = true,
+  stdout = false
+}
+
 return M


### PR DESCRIPTION
Like so:
```lua
            ft('javascript')
                :fmt('prettierd')
                :env({ XDG_RUNTIME_DIR = vim.env.XDG_DATA_HOME .. '/prettierd' })
```

Preserves rest of environment like normal using `uv.environ()` call.