### PR TITLE
feat(#44): support env var specification

### DIFF
--- a/lua/guard/filetype.lua
+++ b/lua/guard/filetype.lua
@@ -42,14 +42,20 @@ local function box()
     return self
   end
 
-  function tbl:env(...)
+  function tbl:env(env)
+    vim.validate({
+      env = { env, 'table' }
+    })
+    if vim.tbl_count(env) == 0 then
+      return self
+    end
     local tool = self[current][#self[current]]
     if type(tool) == 'string' then
       tool = current == 'format' and require('guard.tools.formatter')[tool]
         or require('guard.tools.linter.' .. tool)
     end
     tool.env = {}
-    local env = vim.tbl_extend('force', vim.uv.os_environ(), ... or {})
+    env = vim.tbl_extend('force', vim.uv.os_environ(), env or {})
     for k, v in pairs(env) do
       table.insert(tool.env, ('%s=%s'):format(k, tostring(v)))
     end

--- a/lua/guard/filetype.lua
+++ b/lua/guard/filetype.lua
@@ -42,6 +42,20 @@ local function box()
     return self
   end
 
+  function tbl:env(...)
+    local tool = self[current][#self[current]]
+    if type(tool) == 'string' then
+      tool = current == 'format' and require('guard.tools.formatter')[tool]
+        or require('guard.tools.linter.' .. tool)
+    end
+    tool.env = {}
+    local env = vim.tbl_extend('force', vim.uv.os_environ(), ... or {})
+    for k, v in pairs(env) do
+      table.insert(tool.env, ('%s=%s'):format(k, tostring(v)))
+    end
+    return self
+  end
+
   function tbl:key_alias(key)
     local _t = {
       ['lint'] = function()

--- a/lua/guard/filetype.lua
+++ b/lua/guard/filetype.lua
@@ -57,7 +57,7 @@ local function box()
     tool.env = {}
     env = vim.tbl_extend('force', vim.uv.os_environ(), env or {})
     for k, v in pairs(env) do
-      table.insert(tool.env, ('%s=%s'):format(k, tostring(v)))
+      tool.env[#tool.env + 1 ] = ('%s=%s'):format(k, tostring(v))
     end
     return self
   end

--- a/lua/guard/spawn.lua
+++ b/lua/guard/spawn.lua
@@ -37,7 +37,7 @@ local function spawn(opt)
     stdio = { stdin, stdout, stderr },
     args = opt.args,
     cwd = opt.cwd,
-    env = opt.env_flat or nil,
+    env = opt.env,
   }, function(exit_code, signal)
     if timeout then
       timeout:stop()


### PR DESCRIPTION
support env var spec like so:

```lua
ft('cpp'):fmt('clang-format'):env({ A = 'b' })
```


maintains existing env vars (does not override other than what's specified)