### PR TITLE
feat(lint): support selene

### DIFF
--- a/lua/guard/lint.lua
+++ b/lua/guard/lint.lua
@@ -123,10 +123,15 @@ local function from_json(opts)
     end
 
     vim.tbl_map(function(mes)
+      local lnum = type(opts.attributes.lnum) == 'function' and opts.attributes.lnum(mes)
+        or mes[opts.attributes.lnum]
+      local col = type(opts.attributes.col) == 'function' and opts.attributes.col(mes)
+        or mes[opts.attributes.col]
+
       diags[#diags + 1] = diag_fmt(
         buf,
-        tonumber(mes[opts.attributes.lnum] - opts.offset),
-        tonumber(mes[opts.attributes.col] - opts.offset),
+        tonumber(lnum) - opts.offset,
+        tonumber(col) - opts.offset,
         ('%s [%s]'):format(mes[opts.attributes.message], mes[opts.attributes.code]),
         opts.severities[mes[opts.attributes.severity]],
         opts.source

--- a/lua/guard/tools/linter/selene.lua
+++ b/lua/guard/tools/linter/selene.lua
@@ -1,0 +1,24 @@
+local lint = require('guard.lint')
+
+return {
+  cmd = 'selene',
+  args = { '--no-summary', '--display-style', 'json2' },
+  stdin = true,
+  parse = lint.from_json({
+    attributes = {
+      lnum = function(offence)
+        return offence.primary_label.span.start_line
+      end,
+      col = function(offence)
+        return offence.primary_label.span.start_column
+      end,
+    },
+    severities = {
+      Error = lint.severities.error,
+      Warning = lint.severities.warning,
+    },
+    lines = true,
+    offset = 0,
+    source = 'selene',
+  }),
+}


### PR DESCRIPTION
linters sometimes use config files to know how to format - optional cwd() field passed to uv.spawn() supports this.

Most of this code will go into guard-collection in future

Planning to refactor linting out to make a lot easier in guard-collection. Going to stop all these prs for tools - need to focus on testing after this.

PR also uses cwd() in a demo with selene linter.