### PR TITLE
fix: silent error message

### DIFF
--- a/lua/guard/spawn.lua
+++ b/lua/guard/spawn.lua
@@ -70,7 +70,7 @@ local function spawn(opt)
   end)
 
   if not handle then
-    print('Failed to spawn process ' .. opt.cmd)
+    on_failed('Failed to spawn process ' .. opt.cmd)
     return
   end
 


### PR DESCRIPTION
When running in au print is silent, so no exe error was not shown.