### PR TITLE
feat(lint): let attributes be functions

### DIFF
--- a/lua/guard/lint.lua
+++ b/lua/guard/lint.lua
@@ -126,17 +126,16 @@ local function from_json(opts)
     end
 
     vim.tbl_map(function(mes)
-      local lnum = type(opts.attributes.lnum) == 'function' and opts.attributes.lnum(mes)
-        or mes[opts.attributes.lnum]
-      local col = type(opts.attributes.col) == 'function' and opts.attributes.col(mes)
-        or mes[opts.attributes.col]
+      local attr_value = function(attribute)
+        return type(attribute) == 'function' and attribute(mes) or mes[attribute]
+      end
 
       diags[#diags + 1] = diag_fmt(
         buf,
-        tonumber(lnum) - opts.offset,
-        tonumber(col) - opts.offset,
-        ('%s [%s]'):format(mes[opts.attributes.message], mes[opts.attributes.code]),
-        opts.severities[mes[opts.attributes.severity]],
+        tonumber(attr_value(opts.attributes.lnum)) - opts.offset,
+        tonumber(attr_value(opts.attributes.col)) - opts.offset,
+        ('%s [%s]'):format(attr_value(opts.attributes.message), attr_value(opts.attributes.code)),
+        opts.severities[attr_value(opts.attributes.severity)],
         opts.source
       )
     end, offences or {})


### PR DESCRIPTION
This change is prompted by a change in the python linter ruff. The json output has changed a bit and the severity no longer simply parsed. Example:
```python
import random
```
```json
[
  {
    "code": "F401",
    "message": "`random` imported but unused",
    "fix": {
      "applicability": "Unspecified",
      "message": "Remove unused import: `random`",
      "edits": [
        {
          "content": "",
          "location": {
            "row": 1,
            "column": 1
          },
          "end_location": {
            "row": 2,
            "column": 1
          }
        }
      ]
    },
    "location": {
      "row": 1,
      "column": 8
    },
    "end_location": {
      "row": 1,
      "column": 14
    },
    "filename": "/tmp/tmp.zV0Bmo7zZd/tmp.py",
    "noqa_row": 1
  }
]
```

By making all `attributes` in `from_json` a function or a key to the json message table, we can again extract the severity.
The new ruff config would be something like this:
```lua
{
  cmd = "ruff",
  args = {
    "-n",
    "-e",
    "--format",
    "json",
    "-",
    "--stdin-filename",
  },
  fname = true,
  stdin = true,
  parse = lint.from_json({
    attributes = {
      severity = function(js)
        return string.sub(js["code"], 1, 1) -- first character
      end,
      lnum = function(js)
        return js["location"]["row"]
      end,
      col = function(js)
        return js["location"]["column"]
      end,
    },
    severities = {
      E = lint.severities.error, -- pycodestyle errors
      W = lint.severities.warning, -- pycodestyle warnings
      F = lint.severities.info, -- pyflakes
      A = lint.severities.info, -- flake8-builtins
      B = lint.severities.warning, -- flake8-bugbear
      C = lint.severities.warning, -- flake8-comprehensions
      T = lint.severities.info, -- flake8-print
      U = lint.severities.info, -- pyupgrade
      D = lint.severities.info, -- pydocstyle
      M = lint.severities.into, -- Meta
    },
    source = "ruff",
  }),
}
```
I have tested this on my machine, but as this is part of https://github.com/nvimdev/guard-collection I didn't add or alter any test in this repo. Let me know what you think about this change :)