### PR TITLE
Define argument fmt_on_save

### DIFF
--- a/lua/guard/events.lua
+++ b/lua/guard/events.lua
@@ -22,7 +22,7 @@ local function watch_ft(fts)
   })
 end
 
-local function create_lspattach_autocmd()
+local function create_lspattach_autocmd(fmt_on_save)
   api.nvim_create_autocmd('LspAttach', {
     group = group,
     callback = function(args)


### PR DESCRIPTION
Fix to 6c27cc4 (for https://github.com/nvimdev/guard.nvim/issues/119)

The `create_lspattach_autocmd` function in that commit didn't have a `fmt_on_save` argument, which caused an undefined variable error.
Simply add `fmt_on_save` as an argument; tested and works properly.