### PR TITLE
fix(#111): resolve windows executable paths

### DIFF
--- a/lua/guard/spawn.lua
+++ b/lua/guard/spawn.lua
@@ -35,7 +35,8 @@ local function spawn(opt)
     end)
   end
 
-  handle = uv.spawn(opt.cmd, {
+  local cmd = vim.fn.exepath(opt.cmd)
+  handle = uv.spawn(cmd, {
     stdio = { stdin, stdout, stderr },
     args = opt.args,
     cwd = opt.cwd,


### PR DESCRIPTION
resolves #111 - `uv.spawn()` fails to detect programs as executable on windows. Use `exepath()` to resolve paths before spawn.