### PR TITLE
ci: luarocks workflow

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,18 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags: # Will upload to luarocks.org when a tag is pushed
+      - "*"
+  pull_request: # Will test a local install without uploading to luarocks.org
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          release-type: simple

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # guard.nvim
+[![LuaRocks](https://img.shields.io/luarocks/v/nvimdev/guard.nvim?logo=lua&color=green)](https://luarocks.org/modules/nvimdev/guard.nvim)
 
 Async formatting and linting utility for neovim.
 


### PR DESCRIPTION
#125 continued
This enables automatic versioning and  change log generation via `release-please` (parses conventional commit messages and creates automatic prs)
Also luarocks, I believe, will be the future for the neovim plugin system. This would also push `guard.nvim` to `luarocks.org` every time a tag is released
Just need to add 2 repo secrets and it will all work out :)