### PR TITLE
remove redundant newlines in lint

### DIFF
--- a/lua/guard/lint.lua
+++ b/lua/guard/lint.lua
@@ -16,7 +16,6 @@ local ft_handler = require('guard.filetype')
 local util = require('guard.util')
 local ns = api.nvim_create_namespace('Guard')
 local spawn = require('guard.spawn')
-local get_prev_lines = require('guard.util').get_prev_lines
 local vd = vim.diagnostic
 local M = {}
 
@@ -49,7 +48,7 @@ function M.do_lint(buf)
     return util.should_run(config, buf, startpath, root_dir)
   end, linters)
 
-  local prev_lines = get_prev_lines(buf, 0, -1)
+  local prev_lines = api.nvim_buf_get_lines(buf, 0, -1, false)
   vd.reset(ns, buf)
 
   coroutine.resume(coroutine.create(function()


### PR DESCRIPTION
In #150, guard.nvim started writing double newlines to the linter.

guard.nvim adds a newline to the end of each line:
https://github.com/nvimdev/guard.nvim/blob/6c3b3cb4e61446fa74ccec1a22f300efe541838a/lua/guard/util.lua#L9-L16

and then nvim's SystemObj:write() adds a newline to the end of every line it writes:
https://github.com/neovim/neovim/blob/5331f87f6145f705c73c5c23f365cecb9fbc5067/runtime/lua/vim/_system.lua#L122-L125

which means every newline is doubled, so the linter gets line numbers wrong and keeps complaining about there being too many newlines. This PR replaces the call to `get_prev_lines()` with a direct call to the nvim api so that there are no additional newlines added.