### PR TITLE
fix(lint): handle linter output correctly

### DIFF
--- a/lua/guard/lint.lua
+++ b/lua/guard/lint.lua
@@ -69,6 +69,8 @@ function M.do_lint_single(buf, config)
         vim.log.levels.WARN
       )
       data = ''
+    else
+      data = out
     end
   else
     data = lint.fn(prev_lines)


### PR DESCRIPTION
Ensure that the linter output is correctly assigned to the `data` variable when the output is not an error. This fixes a potential issue where the `data` variable could be left empty even when the linter produces valid output.