### PR TITLE
fix: respect save_on_fmt configuration

### DIFF
--- a/lua/guard/format.lua
+++ b/lua/guard/format.lua
@@ -42,7 +42,7 @@ local function update_buffer(bufnr, prev_lines, new_lines, srow, erow, old_inden
     restore_views(views)
   end
 
-  if need_write or util.getopt('save_on_fmt') then
+  if util.getopt('save_on_fmt') and need_write then
     api.nvim_command('silent! noautocmd write!')
   end
 end


### PR DESCRIPTION
guard always writes buffer since e5cda9be017aaf65eb670dc7d793fcda67230c87 even I specifically set `save_on_fmt = false`