### PR TITLE
feat(lint): add `stderr` and `ignore_exit_code` options

### DIFF
--- a/lua/guard/_meta.lua
+++ b/lua/guard/_meta.lua
@@ -28,6 +28,8 @@
 ---@field env table<string, string>?
 ---@field timeout integer?
 ---@field health function?
+---@field stderr boolean?
+---@field ignore_exit_code boolean?
 
 ---@alias LintConfig LintConfigTable|fun(): LintConfigTable
 

--- a/lua/guard/lint.lua
+++ b/lua/guard/lint.lua
@@ -12,7 +12,7 @@ local custom_ns = {}
 ---@async
 ---@param cmd string[]
 ---@param cwd string
----@param config {env: table?, timeout: integer?}
+---@param config {env: table?, timeout: integer?, stderr: boolean?, ignore_exit_code: boolean?}
 ---@param input string|string[]
 ---@return string output
 ---@return {code: integer, stderr: string, cmd: string}? error
@@ -31,7 +31,7 @@ local function exec_linter(cmd, cwd, config, input)
     handle:write(nil)
   end)
 
-  if result.code ~= 0 and #result.stderr > 0 then
+  if not config.ignore_exit_code and result.code ~= 0 and #result.stderr > 0 then
     return '', {
       code = result.code,
       stderr = result.stderr,
@@ -39,7 +39,7 @@ local function exec_linter(cmd, cwd, config, input)
     }
   end
 
-  return result.stdout, nil
+  return config.stderr and result.stderr or result.stdout, nil
 end
 
 ---@param buf number?

--- a/lua/guard/util.lua
+++ b/lua/guard/util.lua
@@ -176,6 +176,8 @@ function M.toolcopy(c)
     timeout = c.timeout,
     parse = c.parse,
     health = c.health,
+    stderr = c.stderr,
+    ignore_exit_code = c.ignore_exit_code,
   }
 end
 


### PR DESCRIPTION
some linters output to stderr and exit non-zero on lint findings. for example, `cpplint` writes diagnostics to stderr and exits non-zero when it finds style issues - even though the code compiles fine.

currently, `guard.nvim` treats this as a failure so i considered adding two options.

- `stderr`: capture stderr instead of stdout
- `ignore_exit_code`: don't treat non-zero exit as error

```lua
ft('cpp'):lint({
    cmd = 'cpplint',
    fname = true,
    stderr = true,
    ignore_exit_code = true,
    parse = ...,
})
```

also, i'm about to make a pr to `guard-collection` for cpplint that depends on this soon (and a bunch of other prs for other formatters/linters, since im swapping from `none-ls` to guard...).